### PR TITLE
chg: usr: Changed HALO_API_HOST to HALO_API_HOSTNAME.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN /usr/bin/python -mpy.test --cov=ehdlib --cov-report=term-missing /app/test -
 FROM docker.io/halotools/python-sdk:ubuntu-16.04_sdk-1.0.6 as downloader
 MAINTAINER toolbox@cloudpassage.com
 
+ENV HALO_API_HOSTNAME=api.cloudpassage.com
+
 RUN mkdir /app
 
 COPY app/ /app/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Optionally, set these environment variables, if your environment requires them:
 
 | Variable name            | Purpose                                                                |
 |--------------------------|------------------------------------------------------------------------|
-| `HALO_API_HOST`          | Hostname for Halo API.  Default: `api.cloudpassage.com`                |
+| `HALO_API_HOSTNAME`      | Hostname for Halo API.  Default: `api.cloudpassage.com`                |
 | `SLACK_ROUTING`          | Slack message routing rules.  See below...                             |
 | `SLACK_CHANNEL`          | Default channel for Slack notifications. If unset, defaults to `halo`. |
 | `SLACK_API_TOKEN`        | API token for Slack                                                    |

--- a/app/ehdlib/utility.py
+++ b/app/ehdlib/utility.py
@@ -50,8 +50,8 @@ class Utility(object):
         """Return a dict with Halo configuration information."""
         config = {"api_key": os.getenv("HALO_API_KEY"),
                   "api_secret": os.getenv("HALO_API_SECRET_KEY")}
-        if os.getenv("HALO_API_HOST"):
-            config["api_host"] = os.getenv("HALO_API_HOST")
+        if os.getenv("HALO_API_HOSTNAME"):
+            config["api_host"] = os.getenv("HALO_API_HOSTNAME")
         return config
 
     @classmethod


### PR DESCRIPTION
This changes the behavior of the tool. HALO_API_HOST was used
to define the hostname the SDK used to reach the Halo API.
Going forward, users should transition to using HALO_API_HOSTNAME
for this.

The default value of `api.cloudpassage.com` is now set, in the
Dockerfile, for HALO_API_HOSTNAME. Any users that currently use
this tool against MTG will not need to change anything. Non-MTG
users will need to update their container launch environment
variables.

Closes #7